### PR TITLE
fix: unterminated string literal

### DIFF
--- a/src/generate/generate-event-listener-types/generate-event-listener-types.ts
+++ b/src/generate/generate-event-listener-types/generate-event-listener-types.ts
@@ -24,7 +24,7 @@ export const generateEventListenerTypes = (cmp: ComponentCompilerMeta): { htmlEl
     htmlElementEventListenerProperties: [
       `${TABS[2]}addEventListener<K extends keyof ${htmlElementEventMapName}>(type: K, listener: (this: ${htmlElementName}, ev: ${cmpEventInterface}<${htmlElementEventMapName}[K]>) => any, options?: boolean | AddEventListenerOptions): void;`,
       `${TABS[2]}addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;`,
-      `${TABS[2]}addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',`,
+      `${TABS[2]}addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;`,
       `${TABS[2]}addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;`,
       `${TABS[2]}removeEventListener<K extends keyof ${htmlElementEventMapName}>(type: K, listener: (this: ${htmlElementName}, ev: ${cmpEventInterface}<${htmlElementEventMapName}[K]>) => any, options?: boolean | EventListenerOptions): void;`,
       `${TABS[2]}removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;`,

--- a/src/plugin/generator/generator.spec.ts
+++ b/src/plugin/generator/generator.spec.ts
@@ -148,7 +148,7 @@ describe('generator', () => {
       `${TABS[1]}interface HTMLFirstCmpElement {`,
       `${TABS[2]}addEventListener<K extends keyof HTMLFirstCmpElementEventMap>(type: K, listener: (this: HTMLFirstCmpElement, ev: FirstCmpCustomEvent<HTMLFirstCmpElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;`,
       `${TABS[2]}addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;`,
-      `${TABS[2]}addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',`,
+      `${TABS[2]}addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;`,
       `${TABS[2]}addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;`,
       `${TABS[2]}removeEventListener<K extends keyof HTMLFirstCmpElementEventMap>(type: K, listener: (this: HTMLFirstCmpElement, ev: FirstCmpCustomEvent<HTMLFirstCmpElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;`,
       `${TABS[2]}removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;`,


### PR DESCRIPTION
Hi buddy, really great work on putting this together.

I have installed your package and tested it.
In a couple of places, I noticed that the script did not import all CustomEvents from components in components.event-listeners.d.ts, but I can easily add those manually, 2 or 3 were missing. 
What was the problem for me is Typescript error: Unterminated string literal.
I think I located the issue, but please take a look once again on the files I changed.

Here is a screenshot of the issue: 

![Screenshot 2023-12-20 at 14 02 54](https://github.com/m-thompson-code/event-listener-types-output-target/assets/17004063/fc737d85-7b95-4cd2-8cd9-b39b73367528)
